### PR TITLE
Add weighted tables

### DIFF
--- a/decide.el
+++ b/decide.el
@@ -153,7 +153,7 @@
                           "2>>5 small goblins"
                           "level 1--10 hero"
                           "example-dragon"))
-    ("example-dragon" . ("dragon"
+    ("example-dragon" . (("dragon" . 3)
                          "example-dragon-prefix~dragon"
                          "2-3 example-dragon-prefix~dragons"
                          "example-dragon-prefix~dragon"
@@ -304,11 +304,29 @@
              (mapcar 'decide-choose-from-table-list-part
                   (split-string choice "~")) ""))
 
+(defun decide-weight-for-choice (choice)
+  (if (listp choice) (cdr choice) 1))
+
+(defun decide-entry-for-choice (choice)
+  (if (listp choice) (car choice) choice))
+
+(defun decide-table-sum (choices)
+  (seq-reduce
+   (lambda (s v) (+ s (decide-weight-for-choice v)))
+   choices 0))
+
+;; (decide-table-sum '("a" "b" ("c" . 10) "d"))
+
 (defun decide-choose-from-table-choices (choices)
-  (let ((choice (nth (random (length choices)) choices)))
-    (if (stringp choice)
-        (decide-choose-from-table-list choice)
-      "")))
+  (let* ((max (decide-table-sum choices))
+         (roll (decide-from-range-draw (cons 0 max)))
+         (sum 0))
+    (cl-loop for c in choices
+             for e = (decide-entry-for-choice c)
+             for w = (decide-weight-for-choice c)
+             sum w into sum
+             until (< roll sum)
+             finally return e)))
 
 (defun decide-choose-from-table (table-name)
   (let ((choices (cdr (assoc table-name decide-tables))))


### PR DESCRIPTION
Addresses #6. Table entries can now be a cons cell featuring a numeric weight value as the cdr. The dragon example shows how that works. Any entries not featuring a weight are considered to have weight of 1.