### PR TITLE
Fix error: undefined function decide-roll-die-nonempty

### DIFF
--- a/decide.el
+++ b/decide.el
@@ -518,7 +518,7 @@
       (decide-roll-die-nonempty decide-default-dice-faces)
     (decide-roll-die-nonempty faces)))
 
-(defun decide-roll-die (faces)
+(defun decide-roll-die-nonempty (faces)
   (cond ((stringp faces)
          (let ((sides (cdr (assoc-string faces decide-custom-dice t))))
            (if sides


### PR DESCRIPTION
When enabling the minor mode and trying to roll a die, I get the message:

> decide-roll-die: Symbol’s function definition is void: decide-roll-die-nonempty

Apparently the function is [being called](https://github.com/lifelike/decide-mode/blob/b4feee9d5ad32c7b73ab3e1da5cfcdab532754c2/decide.el#L518-L519) but is never defined. Instead, `decide-roll-die` is defined twice ([one](https://github.com/lifelike/decide-mode/blob/b4feee9d5ad32c7b73ab3e1da5cfcdab532754c2/decide.el#L516), [two](https://github.com/lifelike/decide-mode/blob/b4feee9d5ad32c7b73ab3e1da5cfcdab532754c2/decide.el#L521)). Perhaps this is a typo; changing the name of the second definition to `decide-roll-die-nonempty` fixes the problem.